### PR TITLE
fix(breaking): overhauling the group config system to be handler based

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ php artisan vendor:publish --provider="ReadMe\ServiceProvider"
 ```
 
 2. In `config/readme.php`, change `api_key` to the API key we provide to you in your ReadMe project on https://dash.readme.io.
-3. Also in that config file, you'll need to change the `group` closure to return data relevant to your codebase and users. We've provided some simple defaults but you'll likely need to change them.
+3. Also in that config file you will see a `group_handler` that will be set to `App\Handler\ReadMe::class`. This file will exist within `app\Handler` in your application and you should change the contents of its `constructGroup` function to return data that's relevant to your codebase and users. We've provided some simple defaults but you'll likely need to change them.
 
-Once you've done all that, add `\ReadMe\Middleware::class` into your API middleware in `app/Http/Kernel.php` and API metrics will start streaming to your ReadMe project.
+Once you've done all that, add `\ReadMe\Middleware::class` into your API middleware in `app/Http/Kernel.php` and API metrics will start streaming to your ReadMe project!

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpunit/phpunit": "^8.4",
         "squizlabs/php_codesniffer": "^3.5",
         "mockery/mockery": "^1.3",
-        "vimeo/psalm": "^3.7"
+        "vimeo/psalm": ">=3.10"
     },
     "extra": {
         "laravel": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
+    totallyTyped="true"
+    errorLevel="2"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
@@ -9,48 +10,15 @@
     <projectFiles>
         <directory name="src" />
         <ignoreFiles>
-            <file name="src/config.dist.php" />
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
 
     <issueHandlers>
-        <LessSpecificReturnType errorLevel="info" />
-
-        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
-
-        <DeprecatedMethod errorLevel="info" />
-        <DeprecatedProperty errorLevel="info" />
-        <DeprecatedClass errorLevel="info" />
-        <DeprecatedConstant errorLevel="info" />
-        <DeprecatedFunction errorLevel="info" />
-        <DeprecatedInterface errorLevel="info" />
-        <DeprecatedTrait errorLevel="info" />
-
-        <InternalMethod errorLevel="info" />
-        <InternalProperty errorLevel="info" />
-        <InternalClass errorLevel="info" />
-
-        <MissingClosureReturnType errorLevel="info" />
-        <MissingReturnType errorLevel="info" />
-        <MissingPropertyType errorLevel="info" />
-        <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
-
-        <PropertyNotSetInConstructor errorLevel="info" />
-        <MissingConstructor errorLevel="info" />
-        <MissingClosureParamType errorLevel="info" />
-        <MissingParamType errorLevel="info" />
-
-        <RedundantCondition errorLevel="info" />
-
-        <DocblockTypeContradiction errorLevel="info" />
-        <RedundantConditionGivenDocblockType errorLevel="info" />
-
-        <UnresolvableInclude errorLevel="info" />
-
-        <RawObjectIteration errorLevel="info" />
-
-        <InvalidStringClass errorLevel="info" />
+        <InvalidReturnType>
+            <errorLevel type="suppress">
+                <file name="src/handler.dist.php" />
+            </errorLevel>
+        </InvalidReturnType>
     </issueHandlers>
 </psalm>

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -1,0 +1,9 @@
+<?php
+namespace ReadMe;
+
+use Illuminate\Http\Request;
+
+interface Handler
+{
+    public static function constructGroup(Request $request): array;
+}

--- a/src/Metrics.php
+++ b/src/Metrics.php
@@ -30,8 +30,8 @@ class Metrics
     /** @var array */
     private $whitelist = [];
 
-    /** @var Closure */
-    private $group;
+    /** @var class-string */
+    private $group_handler;
 
     /** @var CurlMultiHandler */
     private $curl_handler;
@@ -42,16 +42,23 @@ class Metrics
     /** @var string */
     private $package_version;
 
-    public function __construct(string $api_key, Closure $group, array $options = [])
+    /**
+     * @param string $api_key
+     * @param class-string $group_handler
+     * @param array $options
+     */
+    public function __construct(string $api_key, string $group_handler, array $options = [])
     {
         $this->api_key = $api_key;
-        $this->group = $group;
+        $this->group_handler = $group_handler;
         $this->development_mode = array_key_exists('development_mode', $options)
             ? (bool)$options['development_mode']
             : false;
 
-        $this->blacklist = array_key_exists('blacklist', $options) ? $options['blacklist'] : [];
-        $this->whitelist = array_key_exists('whitelist', $options) ? $options['whitelist'] : [];
+        $this->blacklist = array_key_exists('blacklist', $options) && is_array($options['blacklist'])
+            ? $options['blacklist'] : [];
+        $this->whitelist = array_key_exists('whitelist', $options) && is_array($options['whitelist'])
+            ? $options['whitelist'] : [];
 
         $this->curl_handler = new CurlMultiHandler();
         $this->client = (isset($options['client'])) ? $options['client'] : new Client([
@@ -138,7 +145,7 @@ class Metrics
     public function constructPayload(Request $request, $response): array
     {
         $request_start = (!defined('LARAVEL_START')) ? LARAVEL_START : $_SERVER['REQUEST_TIME_FLOAT'];
-        $group = ($this->group)($request);
+        $group = $this->group_handler::constructGroup($request);
 
         if (!array_key_exists('id', $group)) {
             throw new \TypeError('Metrics grouping function did not return an array with an id present.');

--- a/src/Metrics.php
+++ b/src/Metrics.php
@@ -55,10 +55,13 @@ class Metrics
             ? (bool)$options['development_mode']
             : false;
 
-        $this->blacklist = array_key_exists('blacklist', $options) && is_array($options['blacklist'])
-            ? $options['blacklist'] : [];
-        $this->whitelist = array_key_exists('whitelist', $options) && is_array($options['whitelist'])
-            ? $options['whitelist'] : [];
+        if (isset($options['blacklist']) && is_array($options['blacklist'])) {
+            $this->blacklist = $options['blacklist'];
+        }
+
+        if (isset($options['whitelist']) && is_array($options['whitelist'])) {
+            $this->whitelist = $options['whitelist'];
+        }
 
         $this->curl_handler = new CurlMultiHandler();
         $this->client = (isset($options['client'])) ? $options['client'] : new Client([

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -13,7 +13,7 @@ class Middleware
     {
         $this->metrics = new Metrics(
             config('readme.api_key'),
-            config('readme.group'),
+            config('readme.group_handler'),
             [
                 'development_mode' => config('readme.development_mode', false),
                 'blacklist' => config('readme.blacklist', []),

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -11,6 +11,10 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $this->publishes([
             __DIR__ . '/config.dist.php' => config_path('readme.php'),
+        ], 'config');
+
+        $this->publishes([
+            __DIR__ . '/handler.dist.php' => $path = app_path('Handler/ReadMe.php'),
         ]);
     }
 }

--- a/src/config.dist.php
+++ b/src/config.dist.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Http\Request;
-
 return [
     /**
      * Your ReadMe API key. You can find this within your project configuration
@@ -11,33 +9,10 @@ return [
 
     /**
      * This is a grouping callback that's run for every metric sent to ReadMe,
-     * and is a way for you to group metrics against a specific user. This
-     * function must return an array with at least an `id` key that represents
-     * a unique identifier for the callee (session ID, user ID, etc.).
-     *
-     * Optionally, you may also return the following:
-     *
-     *  - `label`: This will be used to identify the user on ReadMe, since it's
-     *      much easier to remember a name than a unique identifier.
-     *  - `email`: Email of the person that is making the call.
-     *
-     * @link https://docs.readme.com/docs/sending-api-logs-to-readme
+     * and is a way for you to group metrics against a specific user. This class
+     * must implement `ReadMe\Handler`.
      */
-    'group' => function (Request $request): array {
-        // @fixme Replace this code with similar code that's relevant to your application.
-        /* $user = $request->user();
-        if (!$user) {
-            return [
-                'id' => session()->getId()
-            ];
-        }
-
-        return [
-            'id' => $user->id,
-            'label' => $user->name,
-            'email' => $user->email
-        ]; */
-    },
+    'group_handler' => App\Handler\ReadMe::class,
 
     /**
      * Since ReadMe doesn't want to take your API down if you happen to be

--- a/src/handler.dist.php
+++ b/src/handler.dist.php
@@ -1,0 +1,38 @@
+<?php
+namespace App\Handler;
+
+use Illuminate\Http\Request;
+
+class ReadMe implements \ReadMe\Handler
+{
+    /**
+     * This is a grouping callback that's run for every metric sent to ReadMe,
+     * and is a way for you to group metrics against a specific user. This
+     * function must return an array with at least an `id` key that represents
+     * a unique identifier for the callee (session ID, user ID, etc.).
+     *
+     * Optionally, you may also return the following:
+     *
+     *  - `label`: This will be used to identify the user on ReadMe, since it's
+     *      much easier to remember a name than a unique identifier.
+     *  - `email`: Email of the person that is making the call.
+     *
+     * @link https://docs.readme.com/docs/sending-api-logs-to-readme
+     */
+    public static function constructGroup(Request $request): array
+    {
+        // @todo Replace this code with similar code that's relevant to your application.
+        /* $user = $request->user();
+        if (!$user) {
+            return [
+                'id' => session()->getId()
+            ];
+        }
+
+        return [
+            'id' => $user->id,
+            'label' => $user->name,
+            'email' => $user->email
+        ]; */
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -9,7 +9,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame([
             'api_key',
-            'group',
+            'group_handler',
             'development_mode',
             'blacklist',
             'whitelist'

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -9,6 +9,6 @@ class HandlerTest extends \PHPUnit\Framework\TestCase
 
         $handler = new \App\Handler\ReadMe;
 
-        $this->assertTrue($handler instanceof \ReadMe\Handler);
+        $this->assertInstanceOf(\ReadMe\Handler::class, $handler);
     }
 }

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -1,0 +1,14 @@
+<?php
+namespace ReadMe\Tests;
+
+class HandlerTest extends \PHPUnit\Framework\TestCase
+{
+    public function testHandlerImplementsCoreHandler(): void
+    {
+        require_once(__DIR__ . '/../src/handler.dist.php');
+
+        $handler = new \App\Handler\ReadMe;
+
+        $this->assertTrue($handler instanceof \ReadMe\Handler);
+    }
+}

--- a/tests/fixtures/TestHandler.php
+++ b/tests/fixtures/TestHandler.php
@@ -1,0 +1,16 @@
+<?php
+namespace ReadMe\Tests\Fixtures;
+
+use Illuminate\Http\Request;
+
+class TestHandler implements \ReadMe\Handler
+{
+    public static function constructGroup(Request $request): array
+    {
+        return [
+            'id' => '123457890',
+            'label' => 'username',
+            'email' => 'email@example.com'
+        ];
+    }
+}

--- a/tests/fixtures/TestHandlerReturnsEmptyId.php
+++ b/tests/fixtures/TestHandlerReturnsEmptyId.php
@@ -1,0 +1,12 @@
+<?php
+namespace ReadMe\Tests\Fixtures;
+
+use Illuminate\Http\Request;
+
+class TestHandlerReturnsEmptyId implements \ReadMe\Handler
+{
+    public static function constructGroup(Request $request): array
+    {
+        return ['id' => ''];
+    }
+}

--- a/tests/fixtures/TestHandlerReturnsNoData.php
+++ b/tests/fixtures/TestHandlerReturnsNoData.php
@@ -1,0 +1,12 @@
+<?php
+namespace ReadMe\Tests\Fixtures;
+
+use Illuminate\Http\Request;
+
+class TestHandlerReturnsNoData implements \ReadMe\Handler
+{
+    public static function constructGroup(Request $request): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
> ⚠️ This will be a breaking change release and we will need to update our installation guides.

This overhauls the SDK to migrate our configuration handling of `group` from an anonymous closure to a class-based handler. We're doing this because Laravel cannot serialize closures in config files when you run `php artisan config:cache` (something you would do in production environments), which was resulting in the following error:

![Screen Shot 2020-03-31 at 11 09 55 AM](https://user-images.githubusercontent.com/33762/78069974-dae0d600-734f-11ea-99f3-73004de39804.png)

So what's different?

* `readme.group` has been replaced with `readme.group_handler`.
* `readme.group_handler` is now a `class-string` that points to a new `App\Handler\Readme` class that is created when you publish the config per the installation steps.
* `App\Handler\Readme` implements a new `ReadMe\Handler` interface that requires group handlers to implement a `constructGroup` function that replicates the same work that existed in the `readme.group` closure.